### PR TITLE
Add support for Data Format 5 (RAWv2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ following properties (depending on data format):
 * ```accelerationX```
 * ```accelerationY```
 * ```accelerationZ```
+* ```txPower``` -- in data format 5
+* ```movementCounter``` -- in data format 5
+* ```measurementSequenceNumber``` -- in data format 5
 
 See [data formats](https://github.com/ruuvi/ruuvi-sensor-protocols) for
 info about RuuviTag sensor values.

--- a/dataformats/5.js
+++ b/dataformats/5.js
@@ -1,26 +1,25 @@
 const parseRawRuuvi = function(data){
     let robject = {};
   
-    let temperature = (data[3] << 8 | data[4] & 0xFF) / 200.0;
-    if(temperature > 128){           // Ruuvi format, sign bit + value
-      temperature = temperature-128;
-      temperature = 0 - temperature;
+    let temperature = (data[3] << 8 | data[4] & 0xFF);
+    if(temperature > 32767) {
+      temperature -= 65534;
     }
-    robject.temperature = temperature;
+    robject.temperature = temperature / 200.0;
   
     robject.humidity = ((data[5] & 0xFF) << 8 | data[6] & 0xFF) / 400.0;
     robject.pressure = ((data[7] & 0xFF) << 8 | data[8] & 0xFF) + 50000;
   
     let accelerationX = (data[9] << 8 | data[10] & 0xFF);
-    if (accelerationX > 32767) { accelerationX -= 65536;}  //two's complement
+    if (accelerationX > 32767) accelerationX -= 65536;  //two's complement
     robject.accelerationX = accelerationX;
   
     let accelerationY = (data[11] << 8 | data[12] & 0xFF);
-    if (accelerationY > 32767) { accelerationY -= 65536;}  //two's complement
+    if (accelerationY > 32767) accelerationY -= 65536;  //two's complement
     robject.accelerationY = accelerationY;
   
     let accelerationZ = (data[13] << 8 | data[14] & 0xFF);
-    if (accelerationZ > 32767) { accelerationZ -= 65536;}  //two's complement
+    if (accelerationZ > 32767) accelerationZ -= 65536;  //two's complement
     robject.accelerationZ = accelerationZ;
   
     let powerInfo = (data[15] & 0xFF) << 8 | data[16] & 0xFF;

--- a/dataformats/5.js
+++ b/dataformats/5.js
@@ -1,0 +1,37 @@
+const parseRawRuuvi = function(data){
+    let robject = {};
+  
+    let temperature = (data[3] << 8 | data[4] & 0xFF) / 200.0;
+    if(temperature > 128){           // Ruuvi format, sign bit + value
+      temperature = temperature-128;
+      temperature = 0 - temperature;
+    }
+    robject.temperature = temperature;
+  
+    robject.humidity = ((data[5] & 0xFF) << 8 | data[6] & 0xFF) / 400.0;
+    robject.pressure = ((data[7] & 0xFF) << 8 | data[8] & 0xFF) + 50000;
+  
+    let accelerationX = (data[9] << 8 | data[10] & 0xFF);
+    if (accelerationX > 32767) { accelerationX -= 65536;}  //two's complement
+    robject.accelerationX = accelerationX;
+  
+    let accelerationY = (data[11] << 8 | data[12] & 0xFF);
+    if (accelerationY > 32767) { accelerationY -= 65536;}  //two's complement
+    robject.accelerationY = accelerationY;
+  
+    let accelerationZ = (data[13] << 8 | data[14] & 0xFF);
+    if (accelerationZ > 32767) { accelerationZ -= 65536;}  //two's complement
+    robject.accelerationZ = accelerationZ;
+  
+    let powerInfo = (data[15] & 0xFF) << 8 | data[16] & 0xFF;
+    robject.battery = (powerInfo >>> 5) + 1600;
+    robject.txPower = (powerInfo & 0b11111) * 2 - 40;
+    robject.movementCounter = data[17] & 0xFF;
+    robject.measurementSequenceNumber = (data[18] & 0xFF) << 8 | data[19] & 0xFF;
+  
+    return robject;
+  };
+  
+  module.exports = {
+    parse: buffer => parseRawRuuvi(buffer)
+  };

--- a/dataformats/index.js
+++ b/dataformats/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   formats_2_and_4: require('./2and4'),
-  format_3: require('./3')
+  format_3: require('./3'),
+  format_5: require('./5')
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -39,6 +39,13 @@ that.parseUrl = url => {
 };
 
 that.parseManufacturerData = dataBuffer => {
-  // parses data format 3
-  return dataFormats.format_3.parse(dataBuffer);
+  let dataFormat = dataBuffer[2];
+  switch (dataFormat) {
+    case 3:
+      return dataFormats.format_3.parse(dataBuffer);
+    case 5:
+      return dataFormats.format_5.parse(dataBuffer);
+    default:
+      return new Error("Data format not supported");
+  }
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "sinon": "^4.4.2"
   },
   "dependencies": {
-    "noble": "^1.9.0"
+    "@abandonware/noble": "^1.9.2-3"
   }
 }

--- a/ruuvi.js
+++ b/ruuvi.js
@@ -67,11 +67,11 @@ class Ruuvi extends EventEmitter {
 
       if (ruuviTag) {
         if (peripheral.advertisement && peripheral.advertisement.manufacturerData) {
-          // is data format 3
+          let dataFormat = peripheral.advertisement.manufacturerData[2];
           return ruuviTag.emit(
             'updated',
             Object.assign(
-              { dataFormat: 3, rssi: peripheral.rssi },
+              { dataFormat: dataFormat, rssi: peripheral.rssi },
               parser.parseManufacturerData(peripheral.advertisement.manufacturerData))
           );
         }

--- a/ruuvi.js
+++ b/ruuvi.js
@@ -1,4 +1,4 @@
-const noble = require('noble');
+const noble = require('@abandonware/noble');
 const EventEmitter = require('events').EventEmitter;
 const parser = require('./lib/parse');
 const parseEddystoneBeacon = require('./lib/eddystone');


### PR DESCRIPTION
Format specified in https://github.com/ruuvi/ruuvi-sensor-protocols#data-format-5-protocol-specification-rawv2

Sent by Ruuvi firmware 2.4.2 available at https://lab.ruuvi.com/dfu/